### PR TITLE
chore: add shared component internals

### DIFF
--- a/src/components/ControlledTab.tsx
+++ b/src/components/ControlledTab.tsx
@@ -1,5 +1,6 @@
-import React, { forwardRef, useEffect, useId, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import { useControllableState } from '../internal/useControllableState';
+import { useStableId } from '../internal/useStableId';
 import { Tab, type TabProps } from './Tab';
 
 export type ControlledTabOrientation = 'horizontal' | 'vertical';
@@ -126,8 +127,7 @@ function useControlledTabBehavior({
   orientation,
   activationMode,
 }: ControlledTabBehaviorOptions) {
-  const generatedId = useId();
-  const baseId = id ?? `controlled-tab-${generatedId}`;
+  const baseId = useStableId(id, 'controlled-tab');
   const firstEnabledIndex = options.findIndex((option) => !option.disabled);
   const [selectedValue, setSelectedValue] = useControllableState({
     value,

--- a/src/internal/classNames.test.ts
+++ b/src/internal/classNames.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'bun:test';
+import { classNames } from './classNames';
+
+describe('classNames', () => {
+  test('joins class names in deterministic input order', () => {
+    expect(classNames('button', 'button-primary', 'active')).toBe('button button-primary active');
+  });
+
+  test('omits false, null, undefined, and empty conditional values', () => {
+    expect(classNames('button', false, null, undefined, '')).toBe('button');
+  });
+
+  test('flattens nested class-name groups while preserving consumer classes', () => {
+    expect(
+      classNames('button', ['button-primary', [undefined, 'consumer first consumer-second']])
+    ).toBe('button button-primary consumer first consumer-second');
+  });
+});

--- a/src/internal/classNames.ts
+++ b/src/internal/classNames.ts
@@ -1,0 +1,18 @@
+export type ClassNameValue = string | false | null | undefined | readonly ClassNameValue[];
+
+function appendClassNames(tokens: string[], value: ClassNameValue): void {
+  if (Array.isArray(value)) {
+    for (const nestedValue of value) appendClassNames(tokens, nestedValue);
+    return;
+  }
+
+  if (typeof value === 'string' && value.length > 0) tokens.push(value);
+}
+
+export function classNames(...values: readonly ClassNameValue[]): string {
+  const tokens: string[] = [];
+
+  for (const value of values) appendClassNames(tokens, value);
+
+  return tokens.join(' ');
+}

--- a/src/internal/events.test.ts
+++ b/src/internal/events.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, jest, test } from 'bun:test';
+import { composeEventHandlers, type PreventableEvent } from './events';
+
+interface TestEvent extends PreventableEvent {
+  preventDefault(): void;
+}
+
+function createEvent(): TestEvent {
+  return {
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    },
+  };
+}
+
+describe('composeEventHandlers', () => {
+  test('calls the consumer before internal behavior', () => {
+    const calls: string[] = [];
+    const handler = composeEventHandlers<TestEvent>(
+      () => calls.push('consumer'),
+      () => calls.push('internal')
+    );
+
+    handler(createEvent());
+
+    expect(calls).toEqual(['consumer', 'internal']);
+  });
+
+  test('skips internal behavior when the consumer prevents the default', () => {
+    const internalHandler = jest.fn();
+    const handler = composeEventHandlers<TestEvent>(
+      (event) => event.preventDefault(),
+      internalHandler
+    );
+
+    handler(createEvent());
+
+    expect(internalHandler).not.toHaveBeenCalled();
+  });
+
+  test('supports either handler being absent', () => {
+    const consumerHandler = jest.fn();
+    const internalHandler = jest.fn();
+
+    composeEventHandlers(consumerHandler, undefined)(createEvent());
+    composeEventHandlers(undefined, internalHandler)(createEvent());
+
+    expect(consumerHandler).toHaveBeenCalledTimes(1);
+    expect(internalHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/internal/events.ts
+++ b/src/internal/events.ts
@@ -1,0 +1,15 @@
+export interface PreventableEvent {
+  defaultPrevented: boolean;
+}
+
+export type EventHandler<Event extends PreventableEvent> = (event: Event) => void;
+
+export function composeEventHandlers<Event extends PreventableEvent>(
+  consumerHandler: EventHandler<Event> | undefined,
+  internalHandler: EventHandler<Event> | undefined
+): EventHandler<Event> {
+  return (event) => {
+    consumerHandler?.(event);
+    if (!event.defaultPrevented) internalHandler?.(event);
+  };
+}

--- a/src/internal/mergeRefs.test.ts
+++ b/src/internal/mergeRefs.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, jest, test } from 'bun:test';
+import { createRef } from 'react';
+import { mergeRefs } from './mergeRefs';
+
+describe('mergeRefs', () => {
+  test('assigns callback and object refs', () => {
+    const callbackRef = jest.fn();
+    const objectRef = createRef<HTMLButtonElement>();
+    const element = document.createElement('button');
+    const ref = mergeRefs(callbackRef, objectRef, undefined);
+
+    ref(element);
+
+    expect(callbackRef).toHaveBeenCalledWith(element);
+    expect(objectRef.current).toBe(element);
+  });
+
+  test('clears every ref when called with null', () => {
+    const callbackRef = jest.fn();
+    const objectRef = createRef<HTMLButtonElement>();
+    const ref = mergeRefs(callbackRef, objectRef);
+
+    ref(document.createElement('button'));
+    ref(null);
+
+    expect(callbackRef).toHaveBeenLastCalledWith(null);
+    expect(objectRef.current).toBeNull();
+  });
+});

--- a/src/internal/mergeRefs.ts
+++ b/src/internal/mergeRefs.ts
@@ -1,0 +1,15 @@
+import type React from 'react';
+
+export function mergeRefs<Value>(
+  ...refs: readonly (React.Ref<Value> | undefined)[]
+): React.RefCallback<Value> {
+  return (value) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref) {
+        ref.current = value;
+      }
+    }
+  };
+}

--- a/src/internal/useStableId.test.tsx
+++ b/src/internal/useStableId.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { render } from '@testing-library/react';
+import { useStableId } from './useStableId';
+
+function IdFixture({ id, prefix }: { id?: string; prefix?: string }) {
+  const stableId = useStableId(id, prefix);
+  return <div data-testid="fixture" id={stableId} />;
+}
+
+describe('useStableId', () => {
+  test('uses an explicit ID override', () => {
+    const { getByTestId } = render(<IdFixture id="account-field" />);
+
+    expect(getByTestId('fixture').id).toBe('account-field');
+  });
+
+  test('generates unique prefixed IDs', () => {
+    const { getAllByTestId } = render(
+      <>
+        <IdFixture prefix="field" />
+        <IdFixture prefix="field" />
+      </>
+    );
+    const fixtures = getAllByTestId('fixture');
+
+    expect(fixtures[0]?.id.startsWith('field-')).toBe(true);
+    expect(fixtures[1]?.id.startsWith('field-')).toBe(true);
+    expect(fixtures[0]?.id).not.toBe(fixtures[1]?.id);
+  });
+
+  test('retains its generated ID across rerenders', () => {
+    const { getByTestId, rerender } = render(<IdFixture prefix="field" />);
+    const initialId = getByTestId('fixture').id;
+
+    rerender(<IdFixture prefix="field" />);
+
+    expect(getByTestId('fixture').id).toBe(initialId);
+  });
+});

--- a/src/internal/useStableId.ts
+++ b/src/internal/useStableId.ts
@@ -1,0 +1,6 @@
+import { useId } from 'react';
+
+export function useStableId(explicitId?: string, prefix = 'spectre'): string {
+  const generatedId = useId();
+  return explicitId ?? `${prefix}-${generatedId}`;
+}


### PR DESCRIPTION
## Summary

- add focused class-name, event-handler, and merged-ref helpers for upcoming component families
- add a hydration-safe stable ID hook with explicit ID overrides
- migrate `ControlledTab` to the shared stable ID contract
- cover each internal helper with focused unit tests

## Validation

- `bun run ci`
  - 107 unit tests
  - package and React 18/19 compatibility fixtures
  - Storybook build
  - dependency audit